### PR TITLE
Available global config options

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,15 +7,16 @@
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
-    "lib.build": "ng build @mugan86/ng-leaflet",
-    "test.lib": "npm test @mugan86/ng-leaflet",
+    "lib:build": "ng build @mugan86/ng-leaflet",
+    "test:lib": "npm test @mugan86/ng-leaflet",
     "watch:lib": "ng build @mugan86/ng-leaflet --watch",
     "docs:json": "compodoc -p ./tsconfig.json -e json -d .",
     "storybook": "yarn docs:json && start-storybook -p 6006",
     "build-storybook": "yarn docs:json && build-storybook",
     "deploy-storybook": "yarn run build-storybook && npx gh-pages -d storybook-static",
     "lint": "ng lint",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "publish:lib": "yarn publish --access public"
   },
   "private": true,
   "dependencies": {

--- a/projects/mugan86/ng-leaflet/ng-package.json
+++ b/projects/mugan86/ng-leaflet/ng-package.json
@@ -4,5 +4,8 @@
   "lib": {
     "entryFile": "src/public-api.ts"
   },
-  "assets": ["assets"]
+  "allowedNonPeerDependencies": ["leaflet", "@types/leaflet"],
+  "assets": [
+    "assets"
+  ]
 }

--- a/projects/mugan86/ng-leaflet/package.json
+++ b/projects/mugan86/ng-leaflet/package.json
@@ -1,15 +1,14 @@
 {
   "name": "@mugan86/ng-leaflet",
-  "version": "0.0.1",
+  "description": "Angular Version to working with Leaflet Maps library",
+  "version": "0.0.2-beta",
   "peerDependencies": {
     "@angular/common": "^13.0.0",
-    "@angular/core": "^13.0.0",
-    "leaflet": "1.7.1"
-  },
-  "devDependencies": {
-    "@types/leaflet": "^1.4.5"
+    "@angular/core": "^13.0.0"
   },
   "dependencies": {
-    "tslib": "^2.3.0"
+    "@types/leaflet": "^1.4.5",
+    "tslib": "^2.3.0",
+    "leaflet": "1.7.1"
   }
 }

--- a/projects/mugan86/ng-leaflet/package.json
+++ b/projects/mugan86/ng-leaflet/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mugan86/ng-leaflet",
   "description": "Angular Version to working with Leaflet Maps library",
-  "version": "0.0.2-beta",
+  "version": "0.0.5-beta",
   "peerDependencies": {
     "@angular/common": "^13.0.0",
     "@angular/core": "^13.0.0"

--- a/projects/mugan86/ng-leaflet/src/lib/components/map/map.component.ts
+++ b/projects/mugan86/ng-leaflet/src/lib/components/map/map.component.ts
@@ -49,7 +49,21 @@ export class MapComponent implements AfterViewInit {
 
   ngOnInit() {
     // Check if size config exist and if not exist, take default 100% w - 500px h
-    this.size = (this.size) || this.defaultConfig.get().size
+    if (this.size && this.defaultConfig.get().size) {
+      console.warn('Use set size');
+    }
+    if (!this.size && !this.defaultConfig.get().size) {
+      this.size = {
+        width: '100%',
+        height: '500px'
+      };
+      return;
+    }
+    // Check if size config exist and if not exist, take default 100% w - 500px h
+    if (!this.size && this.defaultConfig.get().size) {
+      console.warn('Use default global size');
+      this.size = this.defaultConfig.get().size;
+    }
   }
 
   setConfiguration() {

--- a/projects/mugan86/ng-leaflet/src/lib/components/map/map.component.ts
+++ b/projects/mugan86/ng-leaflet/src/lib/components/map/map.component.ts
@@ -5,6 +5,7 @@ import { Markers } from './../../services/markers';
 import { LeafletMap as Map } from './../../services/ng-leaflet-map.service';
 import { Map as MapObject } from 'leaflet';
 import { ISizeMap } from '../../models/config-map';
+import { DefaultConfig } from '../../services';
 @Component({
   selector: 'ng-leaflet-map',
   templateUrl: './map.component.html',
@@ -44,14 +45,69 @@ export class MapComponent implements AfterViewInit {
   @Output() setUpMap: EventEmitter<MapObject> = new EventEmitter<MapObject>();
   private map!: Map;
 
+  constructor(private defaultConfig: DefaultConfig) { }
+
   ngOnInit() {
-    this.size = (this.size) || {
-      width: '100%',
-      height: '500px'
+    // Check if size config exist and if not exist, take default 100% w - 500px h
+    this.size = (this.size) || this.defaultConfig.get().size
+  }
+
+  setConfiguration() {
+    if (!this.config && this.defaultConfig.get().config) {
+      console.warn('Use default config');
+      this.config = this.defaultConfig.get().config;
+      return;
+    }
+    if (!this.config && !this.defaultConfig.get().config) {
+      console.warn("Use Library default configs \n" + (JSON.stringify({
+        fullscreen: false,
+        center: [43.1824528, -2.3878554],
+        mapId: 'map',
+        zoom: true,
+        zoomValue: 12
+      }, null, 2)));
+      return;
+    }
+    if (this.config && this.defaultConfig.get().config) {
+      console.warn("Overwrite defaultConfig with new set config duplicates values properties");
+      // Rewrite
+      this.checkAndAsignDefaultConfigs()
+    }
+
+  }
+
+  private checkAndAsignDefaultConfigs() {
+
+    if (!this.config!.center && this.defaultConfig.get().config.center) {
+      this.config!.center = this.defaultConfig.get().config.center
+    }
+    if (!this.config!.fullscreen && this.defaultConfig.get().config.fullscreen) {
+      this.config!.fullscreen = this.defaultConfig.get().config.fullscreen
+    }
+
+    if (!this.config!.scale && this.defaultConfig.get().config.scale) {
+      this.config!.scale = this.defaultConfig.get().config.scale
+    }
+
+    if (!this.config!.layers && this.defaultConfig.get().config.layers) {
+      this.config!.layers = this.defaultConfig.get().config.layers
+    }
+
+    if (!this.config!.zoom && this.defaultConfig.get().config.zoom) {
+      this.config!.zoom = this.defaultConfig.get().config.zoom
+    }
+
+    if (!this.config!.watermark && this.defaultConfig.get().config.watermark) {
+      this.config!.watermark = this.defaultConfig.get().config.watermark
+    }
+
+    if (!this.config!.fitBounds && this.defaultConfig.get().config.fitBounds) {
+      this.config!.fitBounds = this.defaultConfig.get().config.fitBounds
     }
   }
 
   ngAfterViewInit(): void {
+    this.setConfiguration();
     this.map = new Map(this.config || undefined, this.mapId || undefined);
     this.markers && (this.markers.length) && Markers.add(this.map.get(), this.markers);
     this.randomMarkers && Markers.add(this.map.get(), [], this.randomMarkers);

--- a/projects/mugan86/ng-leaflet/src/lib/components/map/map.component.ts
+++ b/projects/mugan86/ng-leaflet/src/lib/components/map/map.component.ts
@@ -13,15 +13,15 @@ import { ISizeMap } from '../../models/config-map';
 })
 export class MapComponent implements AfterViewInit {
   /**
-   * Markers
-   */
-  @Input() markers!: Array<IMarker>;
-  /**
    * Assign map ID that need is unique and not duplicate
    * 
    * @required
    */
   @Input() mapId = 'map';
+  /**
+   * Markers
+   */
+  @Input() markers!: Array<IMarker>;
   /**
    * Button contents
    *
@@ -55,7 +55,7 @@ export class MapComponent implements AfterViewInit {
     this.map = new Map(this.config || undefined, this.mapId || undefined);
     this.markers && (this.markers.length) && Markers.add(this.map.get(), this.markers);
     this.randomMarkers && Markers.add(this.map.get(), [], this.randomMarkers);
-    this.markers && this.markers.length && this.config?.fitBounds && this.map.fitBounds(this.markers);
+    this.markers && this.markers.length && this.map.fitBounds(this.markers);
     this.config!! && this.setControls();
     this.setUpMap.emit(this.map.get());
   }

--- a/projects/mugan86/ng-leaflet/src/lib/config/tile-layers/ui.ts
+++ b/projects/mugan86/ng-leaflet/src/lib/config/tile-layers/ui.ts
@@ -14,7 +14,6 @@ const ATRIBUTIONS_LIST = {
         'Map data: &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, <a href="http://viewfinderpanoramas.org">SRTM</a> | Map style: &copy; <a href="https://opentopomap.org">OpenTopoMap</a> (<a href="https://creativecommons.org/licenses/by-sa/3.0/">CC-BY-SA</a>)',
     Stadia:
         '&copy; <a href="https://stadiamaps.com/">Stadia Maps</a>, &copy; <a href="https://openmaptiles.org/">OpenMapTiles</a> &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors',
-    USGS: 'Tiles courtesy of the <a href="https://usgs.gov/">U.S. Geological Survey</a>',
 };
 
 export const tileLayers = {
@@ -76,14 +75,6 @@ export const tileLayers = {
                     'https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png',
             },
             atribution: ATRIBUTIONS_LIST.CartoDb,
-        },
-        usgsUs: {
-            map: {
-                topo: 'https://basemap.nationalmap.gov/arcgis/rest/services/USGSTopo/MapServer/tile/{z}/{y}/{x}',
-                imagery:
-                    'https://basemap.nationalmap.gov/arcgis/rest/services/USGSImageryOnly/MapServer/tile/{z}/{y}/{x}',
-            },
-            atribution: ATRIBUTIONS_LIST.USGS,
         }
     },
     overlayers: {

--- a/projects/mugan86/ng-leaflet/src/lib/models/index.ts
+++ b/projects/mugan86/ng-leaflet/src/lib/models/index.ts
@@ -1,4 +1,4 @@
 import { IMarker } from "./marker";
-import { IConfigMap } from "./config-map";
+import { IConfigMap, ISizeMap } from "./config-map";
 import { IScaleOptions, IBaseLayer, ILayers, IOverLayer, IZoomOptions, IWatermarkOptions } from "./controls"
-export { IMarker, IConfigMap, IScaleOptions, IBaseLayer, ILayers, IOverLayer, IZoomOptions, IWatermarkOptions };
+export { IMarker, ISizeMap, IConfigMap, IScaleOptions, IBaseLayer, ILayers, IOverLayer, IZoomOptions, IWatermarkOptions };

--- a/projects/mugan86/ng-leaflet/src/lib/ng-leaflet.module.ts
+++ b/projects/mugan86/ng-leaflet/src/lib/ng-leaflet.module.ts
@@ -1,5 +1,7 @@
-import { NgModule } from '@angular/core';
+import { ModuleWithProviders, NgModule } from '@angular/core';
 import { MapBasicModule } from './components/map/map.module';
+import { IConfigMap, ISizeMap } from './models';
+import { DefaultConfig } from './services';
 
 @NgModule({
   declarations: [
@@ -11,4 +13,21 @@ import { MapBasicModule } from './components/map/map.module';
     MapBasicModule
   ]
 })
-export class NgLeafletModule { }
+export class NgLeafletModule { 
+  public static forRoot(config?: IConfigMap, size?: ISizeMap): ModuleWithProviders<NgLeafletModule> {
+    return {
+      ngModule: NgLeafletModule,
+      providers: [
+        DefaultConfig,
+        {
+          provide: 'config',
+          useValue: config
+        },
+        {
+          provide: 'size',
+          useValue: size
+        }
+      ]
+    };
+  }
+}

--- a/projects/mugan86/ng-leaflet/src/lib/services/default-config.ts
+++ b/projects/mugan86/ng-leaflet/src/lib/services/default-config.ts
@@ -1,0 +1,23 @@
+import { Inject, Injectable } from "@angular/core";
+import { IConfigMap, ISizeMap } from "../models";
+
+@Injectable({
+    providedIn: 'root'
+})
+export class DefaultConfig {
+    constructor(@Inject('config') private config: IConfigMap,
+        @Inject('size') private size: ISizeMap) {
+        if (!this.size) {
+            this.size = {
+                width: '100%',
+                height: '500px'
+            }
+        }
+    }
+    get() {
+        return {
+            size: this.size,
+            config: this.config
+        }
+    }
+}

--- a/projects/mugan86/ng-leaflet/src/lib/services/index.ts
+++ b/projects/mugan86/ng-leaflet/src/lib/services/index.ts
@@ -1,5 +1,6 @@
 import { LeafletMap as Map} from "./ng-leaflet-map.service";
 import { Markers } from "./markers";
 import { Controls } from './controls';
+import { DefaultConfig } from "./default-config";
 
-export { Map, Markers, Controls };
+export { Map, Markers, Controls, DefaultConfig };

--- a/projects/mugan86/ng-leaflet/src/public-api.ts
+++ b/projects/mugan86/ng-leaflet/src/public-api.ts
@@ -9,3 +9,4 @@ export * from './lib/config/tile-layers/ui';
 export * from './lib/models';
 export * from './lib/services';
 export * from './lib/plugins';
+export * from './lib/examples/locations/world';

--- a/src/app/pages/storybook/map/map.component.html
+++ b/src/app/pages/storybook/map/map.component.html
@@ -1,2 +1,2 @@
-<ng-leaflet-map [size]="size" [markers]="markers" [randomMarkers]="randomMarkers" [config]="config">
+<ng-leaflet-map  [size]="size" [markers]="markers" [randomMarkers]="randomMarkers">
 </ng-leaflet-map>

--- a/src/app/pages/storybook/map/map.component.ts
+++ b/src/app/pages/storybook/map/map.component.ts
@@ -7,8 +7,14 @@ import { IConfigMap, IMarker } from '@mugan86/ng-leaflet';
   styleUrls: ['./map.component.css']
 })
 export class MapComponent {
-  @Input() markers!: Array<IMarker>;
+  @Input() markers: Array<IMarker> = [ {
+    position: {
+      lat: 21.3320135, lng: -157.8287631
+    }
+  }];
   @Input() randomMarkers: boolean = false;
   @Input() size: { width: string, height: string } = { width: '100%', height: '600px' }
-  @Input() config?: IConfigMap;
+  @Input() config?: IConfigMap = {
+    fullscreen: true
+  };
 }

--- a/src/app/pages/storybook/map/map.component.ts
+++ b/src/app/pages/storybook/map/map.component.ts
@@ -7,13 +7,9 @@ import { IConfigMap, IMarker } from '@mugan86/ng-leaflet';
   styleUrls: ['./map.component.css']
 })
 export class MapComponent {
-  @Input() markers: Array<IMarker> = [ {
-    position: {
-      lat: 21.3320135, lng: -157.8287631
-    }
-  }];
-  @Input() randomMarkers: boolean = false;
-  @Input() size: { width: string, height: string } = { width: '100%', height: '600px' }
+  @Input() markers: Array<IMarker> = [ ];
+  @Input() randomMarkers: boolean = true;
+  @Input() size: { width: string, height: string } = { width: '100%', height: '350px' }
   @Input() config?: IConfigMap = {
     fullscreen: true
   };

--- a/src/app/pages/storybook/map/map.component.ts
+++ b/src/app/pages/storybook/map/map.component.ts
@@ -9,7 +9,7 @@ import { IConfigMap, IMarker } from '@mugan86/ng-leaflet';
 export class MapComponent {
   @Input() markers: Array<IMarker> = [ ];
   @Input() randomMarkers: boolean = true;
-  @Input() size: { width: string, height: string } = { width: '100%', height: '350px' }
+  @Input() size: { width: string, height: string } = { width: '100%', height: '250px' }
   @Input() config?: IConfigMap = {
     fullscreen: true
   };

--- a/src/app/pages/storybook/map/map.module.ts
+++ b/src/app/pages/storybook/map/map.module.ts
@@ -3,9 +3,32 @@ import { CommonModule } from '@angular/common';
 
 import { MapRoutingModule } from './map-routing.module';
 import { MapComponent } from './map.component';
-import { NgLeafletModule } from '@mugan86/ng-leaflet';
+import { IConfigMap, NgLeafletModule, tileLayers } from '@mugan86/ng-leaflet';
 
-
+const config: IConfigMap = {
+  fullscreen: true,
+  center: [40.4378698,-3.8196188],
+  zoom: {
+    position: 'topright'
+  },
+  watermark: {
+    show: true,
+    position: 'topleft'
+  },
+  layers: {
+    baseLayers: [{
+      label: 'Carto - Positron',
+      map: tileLayers.baseLayers.cartoDb.map.positron,
+      atribution: tileLayers.baseLayers.cartoDb.atribution,
+      default: true
+    },
+    {
+      label: 'Cyclo OSM',
+      map: tileLayers.baseLayers.cycloOsm.map,
+      atribution: tileLayers.baseLayers.cycloOsm.atribution
+    }]
+  }
+}
 @NgModule({
   declarations: [
     MapComponent
@@ -13,7 +36,7 @@ import { NgLeafletModule } from '@mugan86/ng-leaflet';
   imports: [
     CommonModule,
     MapRoutingModule,
-    NgLeafletModule
+    NgLeafletModule.forRoot(config)
   ]
 })
 export class MapModule { }

--- a/src/app/pages/storybook/map/map.module.ts
+++ b/src/app/pages/storybook/map/map.module.ts
@@ -36,7 +36,10 @@ const config: IConfigMap = {
   imports: [
     CommonModule,
     MapRoutingModule,
-    NgLeafletModule.forRoot(config)
+    NgLeafletModule.forRoot(config, {
+      width: '100%',
+      height: '600px'
+    })
   ]
 })
 export class MapModule { }


### PR DESCRIPTION
Add forRoot option to add global config to specify map configurations and size to use by default.

If we use new config in specify component rewrite global options.